### PR TITLE
Update README with dataset instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,29 @@
 # hr-simple-evals
-hr-simple-evals
 
-평가 코드
+This repository contains simple evaluation utilities for Korean language models.
 
+## Running evaluations
 
+Use `evaluation.py` to run a model on a dataset from the [HAERAE-HUB/KoSimpleEval](https://huggingface.co/datasets/HAERAE-HUB/KoSimpleEval) collection. The basic command looks like:
 
+```bash
 python evaluation.py \
-  --model kakaocorp/kanana-1.5-8b-instruct-2505 \
-  --dataset ArenaHard \
+  --model <model-id-or-path> \
+  --dataset <subset-name> \
+  --dataset_hub_id HAERAE-HUB/KoSimpleEval \
   --temperature 0.7 \
   --top_p 0.9 \
-  --reasoning False \
   --max_tokens 1024
+```
 
-이런너낌
+Supported subset names include:
+
+- `ArenaHard`
+- `ClinicalQA`
+- `HRB1_0`
+- `KMMLU_Redux`
+- `MCLM`
+
+Replace `<model-id-or-path>` with the Hugging Face model ID or a local checkpoint.
+
+The script will generate responses using the specified model and evaluate them according to the dataset configuration defined in `dataset_configs.py`.


### PR DESCRIPTION
## Summary
- add instructions for running evaluation with KoSimpleEval subsets

## Testing
- `python evaluation.py --help` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_688761caa42c8320a5f00a6f75a6a4b1