### PR TITLE
Add support for yentinglin/aime_2025 and HuggingFaceH4/aime_2024 datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,36 @@ Supported subset names include:
 - `MCLM`
 - `gpqa-diamond` (You Should use Idavidrein/gpqa - gpqa-diamond subset for evaluation)
 - `KSM` (You Should use HAERAE-HUB/HRM8K - KSM subset for evaluation)
+- `default` (You can use yentinglin/aime_2025 or HuggingFaceH4/aime_2024 for evaluation)
 
 Replace `<model-id-or-path>` with the Hugging Face model ID or a local checkpoint.
 
 The script will generate responses using the specified model and evaluate them according to the dataset configuration defined in `dataset_configs.py`.
+
+## Using AIME datasets
+
+You can evaluate models on the AIME (American Invitational Mathematics Examination) datasets:
+
+### AIME 2025
+```bash
+python evaluation.py \
+  --model <model-id-or-path> \
+  --dataset default \
+  --dataset_hub_id yentinglin/aime_2025 \
+  --split train \
+  --temperature 0.0 \
+  --max_tokens 1024
+```
+
+### AIME 2024
+```bash
+python evaluation.py \
+  --model <model-id-or-path> \
+  --dataset default \
+  --dataset_hub_id HuggingFaceH4/aime_2024 \
+  --split train \
+  --temperature 0.0 \
+  --max_tokens 1024
+```
+
+These datasets contain challenging mathematics problems that test a model's mathematical reasoning capabilities.

--- a/dataset_configs.py
+++ b/dataset_configs.py
@@ -48,10 +48,16 @@ def _create_prompt_for_mqa(row, tokenizer):
         f"{row['choices']}\n\n" # 'choices' 컬럼이 선택지를 포함한 문자열이라고 가정
         "정답:"
     )
-    return tokenizer.apply_chat_template(
-        [{"role": "user", "content": query}],
-        tokenize=False, add_generation_prompt=True
-    )
+    
+    # Check if the tokenizer has a chat template
+    try:
+        return tokenizer.apply_chat_template(
+            [{"role": "user", "content": query}],
+            tokenize=False, add_generation_prompt=True
+        )
+    except (ValueError, AttributeError):
+        # Fallback for models without chat templates
+        return query
 
 def _create_prompt_for_kobalt(row, tokenizer):
     """Kobalt (https://arxiv.org/pdf/2505.16125) Figure 2."""
@@ -61,36 +67,64 @@ def _create_prompt_for_kobalt(row, tokenizer):
         f"답변은 반드시 다음 형식을 엄격히 지켜야 합니다: \"정답은 [정답 보기]입니다.\"로 끝나야하고, [정답 보기]는 A, B, C, D, E, F, G, H, I, J 중 하나여야 합니다.\n"
         f"문제를 풀기 위해, 한번 천천히 생각해봅시다."
     )
-    return tokenizer.apply_chat_template(
-        [{"role": "user", "content": query}],
-        tokenize=False, add_generation_prompt=True
-    )
+    
+    # Check if the tokenizer has a chat template
+    try:
+        return tokenizer.apply_chat_template(
+            [{"role": "user", "content": query}],
+            tokenize=False, add_generation_prompt=True
+        )
+    except (ValueError, AttributeError):
+        # Fallback for models without chat templates
+        return query
 
 def _create_prompt_for_math(row, tokenizer):
     """수학 문제(AIME, MCLM)를 위한 프롬프트"""
+    # Check if the dataset has 'question' or 'problem' column
+    question_text = row.get('question', row.get('problem', ''))
+    
     query = (
         f"다음 수학 문제를 풀어주세요. 풀이 과정과 함께 최종 답을 '\\boxed{{정답}}' 형식으로 명확하게 제시해주세요.\n\n"
-        f"문제: {row['question']}"
+        f"문제: {question_text}"
     )
-    return tokenizer.apply_chat_template(
-        [{"role": "user", "content": query}],
-        tokenize=False, add_generation_prompt=True
-    )
+    
+    # Check if the tokenizer has a chat template
+    try:
+        return tokenizer.apply_chat_template(
+            [{"role": "user", "content": query}],
+            tokenize=False, add_generation_prompt=True
+        )
+    except (ValueError, AttributeError):
+        # Fallback for models without chat templates
+        return query
 
 def _create_prompt_for_qa(row, tokenizer):
     """일반적인 질의응답 데이터셋을 위한 프롬프트 (GPQA, KoBALT 등)"""
     query = f"다음 질문에 대해 상세하고 정확하게 답변해주세요.\n\n질문: {row['question']}"
-    return tokenizer.apply_chat_template(
-        [{"role": "user", "content": query}],
-        tokenize=False, add_generation_prompt=True
-    )
+    
+    # Check if the tokenizer has a chat template
+    try:
+        return tokenizer.apply_chat_template(
+            [{"role": "user", "content": query}],
+            tokenize=False, add_generation_prompt=True
+        )
+    except (ValueError, AttributeError):
+        # Fallback for models without chat templates
+        return query
 
 def _create_prompt_for_arena(row, tokenizer):
     """Arena 형식 데이터셋을 위한 프롬프트"""
-    return tokenizer.apply_chat_template(
-        [{"role": "user", "content": row['prompts']}],
-        tokenize=False, add_generation_prompt=True
-    )
+    query = row['prompts']
+    
+    # Check if the tokenizer has a chat template
+    try:
+        return tokenizer.apply_chat_template(
+            [{"role": "user", "content": query}],
+            tokenize=False, add_generation_prompt=True
+        )
+    except (ValueError, AttributeError):
+        # Fallback for models without chat templates
+        return query
 
 # ===================================================================
 # 2. 평가 실행 함수 (Evaluators)
@@ -114,7 +148,17 @@ def _evaluate_math(df, args):
     print("🤖 수학 문제 평가를 시작합니다...")
 
     df['pred_answer'] = df['response'].apply(_parse_math_answer)
-    df['gold_answer'] = df['gold'].astype(str) # 정답을 문자열로 통일
+    
+    # Check if the dataset has 'gold' or 'answer' column
+    if 'gold' in df.columns:
+        df['gold_answer'] = df['gold'].astype(str)  # 정답을 문자열로 통일
+    elif 'answer' in df.columns:
+        df['gold_answer'] = df['answer'].astype(str)  # 정답을 문자열로 통일
+    else:
+        print("⚠️ 'gold' 또는 'answer' 컬럼을 찾을 수 없습니다. 평가를 건너뜁니다.")
+        df['gold_answer'] = 'N/A'
+        df['correct'] = False
+        return df
 
     df['correct'] = (df['pred_answer'] == df['gold_answer'])
 
@@ -238,6 +282,8 @@ DATASET_CONFIGS = {
     'kmmlu-pro': {'prompt_maker': _create_prompt_for_mqa, 'evaluator': _evaluate_mqa},
     'aime2025': {'prompt_maker': _create_prompt_for_math, 'evaluator': _evaluate_math},
     'aime2024': {'prompt_maker': _create_prompt_for_math, 'evaluator': _evaluate_math},
+    'default': {'prompt_maker': _create_prompt_for_math, 'evaluator': _evaluate_math},  # For yentinglin/aime_2025 default subset
+    'train': {'prompt_maker': _create_prompt_for_math, 'evaluator': _evaluate_math},    # For HuggingFaceH4/aime_2024 train subset
     'click': {'prompt_maker': _create_prompt_for_mqa, 'evaluator': _evaluate_mqa},
     'kobalt': {'prompt_maker': _create_prompt_for_kobalt, 'evaluator': _evaluate_kobalt},
     'KSM': {'prompt_maker': _create_prompt_for_qa, 'evaluator': _evaluate_hrm8k_ksm},

--- a/dataset_configs.py
+++ b/dataset_configs.py
@@ -48,16 +48,10 @@ def _create_prompt_for_mqa(row, tokenizer):
         f"{row['choices']}\n\n" # 'choices' 컬럼이 선택지를 포함한 문자열이라고 가정
         "정답:"
     )
-    
-    # Check if the tokenizer has a chat template
-    try:
-        return tokenizer.apply_chat_template(
-            [{"role": "user", "content": query}],
-            tokenize=False, add_generation_prompt=True
-        )
-    except (ValueError, AttributeError):
-        # Fallback for models without chat templates
-        return query
+    return tokenizer.apply_chat_template(
+        [{"role": "user", "content": query}],
+        tokenize=False, add_generation_prompt=True
+    )
 
 def _create_prompt_for_kobalt(row, tokenizer):
     """Kobalt (https://arxiv.org/pdf/2505.16125) Figure 2."""
@@ -67,16 +61,10 @@ def _create_prompt_for_kobalt(row, tokenizer):
         f"답변은 반드시 다음 형식을 엄격히 지켜야 합니다: \"정답은 [정답 보기]입니다.\"로 끝나야하고, [정답 보기]는 A, B, C, D, E, F, G, H, I, J 중 하나여야 합니다.\n"
         f"문제를 풀기 위해, 한번 천천히 생각해봅시다."
     )
-    
-    # Check if the tokenizer has a chat template
-    try:
-        return tokenizer.apply_chat_template(
-            [{"role": "user", "content": query}],
-            tokenize=False, add_generation_prompt=True
-        )
-    except (ValueError, AttributeError):
-        # Fallback for models without chat templates
-        return query
+    return tokenizer.apply_chat_template(
+        [{"role": "user", "content": query}],
+        tokenize=False, add_generation_prompt=True
+    )
 
 def _create_prompt_for_math(row, tokenizer):
     """수학 문제(AIME, MCLM)를 위한 프롬프트"""
@@ -87,44 +75,26 @@ def _create_prompt_for_math(row, tokenizer):
         f"다음 수학 문제를 풀어주세요. 풀이 과정과 함께 최종 답을 '\\boxed{{정답}}' 형식으로 명확하게 제시해주세요.\n\n"
         f"문제: {question_text}"
     )
-    
-    # Check if the tokenizer has a chat template
-    try:
-        return tokenizer.apply_chat_template(
-            [{"role": "user", "content": query}],
-            tokenize=False, add_generation_prompt=True
-        )
-    except (ValueError, AttributeError):
-        # Fallback for models without chat templates
-        return query
+    return tokenizer.apply_chat_template(
+        [{"role": "user", "content": query}],
+        tokenize=False, add_generation_prompt=True
+    )
 
 def _create_prompt_for_qa(row, tokenizer):
     """일반적인 질의응답 데이터셋을 위한 프롬프트 (GPQA, KoBALT 등)"""
     query = f"다음 질문에 대해 상세하고 정확하게 답변해주세요.\n\n질문: {row['question']}"
-    
-    # Check if the tokenizer has a chat template
-    try:
-        return tokenizer.apply_chat_template(
-            [{"role": "user", "content": query}],
-            tokenize=False, add_generation_prompt=True
-        )
-    except (ValueError, AttributeError):
-        # Fallback for models without chat templates
-        return query
+    return tokenizer.apply_chat_template(
+        [{"role": "user", "content": query}],
+        tokenize=False, add_generation_prompt=True
+    )
 
 def _create_prompt_for_arena(row, tokenizer):
     """Arena 형식 데이터셋을 위한 프롬프트"""
     query = row['prompts']
-    
-    # Check if the tokenizer has a chat template
-    try:
-        return tokenizer.apply_chat_template(
-            [{"role": "user", "content": query}],
-            tokenize=False, add_generation_prompt=True
-        )
-    except (ValueError, AttributeError):
-        # Fallback for models without chat templates
-        return query
+    return tokenizer.apply_chat_template(
+        [{"role": "user", "content": query}],
+        tokenize=False, add_generation_prompt=True
+    )
 
 # ===================================================================
 # 2. 평가 실행 함수 (Evaluators)

--- a/evaluation.py
+++ b/evaluation.py
@@ -38,60 +38,11 @@ def main() -> None:
         return
     
     print(f"🚀 모델 로딩 중: {args.model}")
-    # Use CPU for testing
-    from transformers import AutoTokenizer, AutoModelForCausalLM
-    tokenizer = AutoTokenizer.from_pretrained(args.model)
-    model = AutoModelForCausalLM.from_pretrained(args.model, device_map="cpu", trust_remote_code=True)
-    
-    # Create a simple wrapper class to mimic vLLM's interface
-    class SimpleGenerationOutput:
-        def __init__(self, text):
-            self.text = text
-            
-    class SimpleOutput:
-        def __init__(self, text):
-            self.outputs = [SimpleGenerationOutput(text)]
-            
-    class SimpleLLM:
-        def __init__(self, model, tokenizer):
-            self.model = model
-            self.tokenizer = tokenizer
-            self.max_length = model.config.max_position_embeddings
-            
-        def get_tokenizer(self):
-            return self.tokenizer
-            
-        def generate(self, prompts, sampling_params):
-            outputs = []
-            for prompt in prompts:
-                try:
-                    # Truncate input if it's too long
-                    inputs = self.tokenizer(prompt, return_tensors="pt", truncation=True, max_length=self.max_length - sampling_params.max_tokens)
-                    
-                    output_ids = self.model.generate(
-                        inputs.input_ids, 
-                        max_new_tokens=sampling_params.max_tokens,
-                        do_sample=sampling_params.temperature > 0,
-                        temperature=max(sampling_params.temperature, 1e-5),  # Avoid division by zero
-                        top_p=sampling_params.top_p
-                    )
-                    
-                    output_text = self.tokenizer.decode(output_ids[0][inputs.input_ids.shape[1]:], skip_special_tokens=True)
-                    outputs.append(SimpleOutput(output_text))
-                except Exception as e:
-                    print(f"Error generating response: {e}")
-                    outputs.append(SimpleOutput("Error generating response"))
-            return outputs
-    
-    llm = SimpleLLM(model, tokenizer)
+    llm = LLM(model=args.model, tensor_parallel_size=torch.cuda.device_count(), trust_remote_code=True)
+    tokenizer = llm.get_tokenizer()
 
     print(f"📚 데이터셋 로딩 중: {args.dataset_hub_id} - {args.dataset}")
     df = load_dataset(args.dataset_hub_id, args.dataset, split=args.split).to_pandas()
-    
-    # For testing purposes, use only a small subset of the data
-    if len(df) > 5:
-        print(f"⚠️ 테스트를 위해 데이터셋을 5개 샘플로 제한합니다 (원래 크기: {len(df)})")
-        df = df.head(5)
 
     print("✍️  프롬프트를 생성하고 있습니다...")
     tqdm.pandas(desc="프롬프트 생성")


### PR DESCRIPTION
이 PR은 다음 데이터셋을 지원하기 위한 변경 사항을 포함합니다:

1. yentinglin/aime_2025 (default subset)
2. HuggingFaceH4/aime_2024 (train subset)

변경 사항:
- dataset_configs.py에서 _create_prompt_for_math 함수를 수정하여 'question'과 'problem' 컬럼 이름을 모두 처리할 수 있도록 함
- dataset_configs.py에서 _evaluate_math 함수를 수정하여 'gold'와 'answer' 컬럼 이름을 모두 처리할 수 있도록 함

이러한 변경 사항은 코드를 더 견고하게 만들고 다양한 데이터셋 구조와 호환되도록 합니다.

이전 PR에서는 vLLM을 사용할 수 없는 환경에서 테스트하기 위해 불필요한 코드가 추가되었으나, 이번 PR에서는 그러한 코드를 제거하고 필요한 변경 사항만 포함했습니다.